### PR TITLE
Problem: if no files supplied, sit CLI will panic

### DIFF
--- a/sit/src/main.rs
+++ b/sit/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
                     exit(1);
                 },
                 Some(issue) => {
-                    let files = matches.values_of("FILES").unwrap();
+                    let files = matches.values_of("FILES").unwrap_or(clap::Values::default());
                     let types: Vec<_> = matches.value_of("type").unwrap().split(",").collect();
 
                     if !files.clone().any(|f| f.starts_with(".type/")) && types.len() == 0 {


### PR DESCRIPTION
This is happening because it assumes that at least
one file will be passed and therefore [confidently]
unwraps the value. But it isn't there...

Solution: specify a default empty value to avoid the problem