### PR TITLE
Problem: README is limiting for record type listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,14 +244,8 @@ an issue looked back then.
 The result of this reduction can be used as-is or in a user interface to produce a
 comprehensible rendering of it.
 
-Currently, the core dictionary processed by SIT is very small (but it is expected to grow):
-
-| Type           | Description                     | Files                                                | State effect                      |
-|----------------|---------------------------------|------------------------------------------------------|-----------------------------------|
-| SummaryChanged | Changes issue's summary (title) | * `text` - a UTF-8 string, expeced to be a one-liner | Updates `summary` field           |
-| DetailsChanged | Changes issue's details (body)  | * `text` - a UTF-8 string                            | Updates `details` field           |
-| Closed         | Closes issue                    |                                                      | Updates `state` field to `closed` |
-| Reopened       | Reopens issue                   |                                                      | Updates `state` field to `open`   |
+Currently, the core dictionary processed by SIT is very small (but it is expected to grow) and
+can be found in [documentation](doc/dict).
 
 One can look at the state of the issue with the `sit reduce <issue id>` command.
 

--- a/doc/dict/Closed.md
+++ b/doc/dict/Closed.md
@@ -1,0 +1,11 @@
+# Closed 
+
+Closes issue
+
+## Files
+
+None
+
+## State Effect
+
+Updates `state` field to `closed`.

--- a/doc/dict/DetailsChanged.md
+++ b/doc/dict/DetailsChanged.md
@@ -1,0 +1,15 @@
+# DetailsChanged
+
+Changes issue's details (body)
+
+## Files
+
+### `text`
+
+Required.
+
+Contains A UTF-8 string describing the issue in details.
+
+## State Effect
+
+Updates `details` field with the value specified in `text`.

--- a/doc/dict/Reopened.md
+++ b/doc/dict/Reopened.md
@@ -1,0 +1,11 @@
+# Reopened 
+
+Reopens the issue after its closure.
+
+## Files
+
+None
+
+## State Effect
+
+Updates `state` field to `open`.

--- a/doc/dict/SummaryChanged.md
+++ b/doc/dict/SummaryChanged.md
@@ -1,0 +1,16 @@
+# SummaryChanged
+
+Changes issue's summary (title)
+
+## Files
+
+### `text`
+
+Required.
+
+Contains A UTF-8 string briefly summarizing the issue. Typically expected to be
+a one-liner.
+
+## State Effect
+
+Updates `summary` field with the value specified in `text`.


### PR DESCRIPTION
Firstly, the table that is used is constraining the
ability to put enough information about each type.

Secondly, eventually this list will just grow
disproportionately long and won't be a good fit
for README.

Solution: move this dictionary to individual files
in documentation and reference them from README