### PR TITLE
Problem: jq workaround for queries is a bit unwelcoming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,17 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jmespath"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slug 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,8 +408,10 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jmespath 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sit-core 0.1.0",
  "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,6 +434,14 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-builder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unidecode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -544,6 +565,11 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unidecode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +655,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+"checksum jmespath 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad96d882ed4978e5d4ef98cb5ac1aa682bf172f180f4af2713f68b7c7f95a232"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
@@ -656,6 +683,7 @@ dependencies = [
 "checksum serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9db7266c7d63a4c4b7fe8719656ccdd51acf1bed6124b174f933b009fb10bcb"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
+"checksum slug 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f5ff4b43cb07b86c5f9236c92714a22cdf9e5a27a7d85e398e2c9403328cb8"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -671,6 +699,7 @@ dependencies = [
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unidecode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2adb95ee07cd579ed18131f2d9e7a17c25a4b76022935c7f2460d2bfae89fd2"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"

--- a/README.md
+++ b/README.md
@@ -91,23 +91,37 @@ to record authorship in issues.
 
 ### Listing issues
 
-While `sit issues` will list all issues by their IDs, this is hardly practical if
-you just want to see a list of issues you want to be able to process quickly.
+By default, `sit issues` will list all issues by their IDs. However,
+this is hardly practical if you just want to see a list of issues you want to be able
+to process quickly, or if you want to search for specific kinds of issues.
 
-Until we've got a better mechanism, it is suggested to use `sit` in conjunction
-with [jq](https://stedolan.github.io/jq/), for exmaple, like this:
+Luckily, sit integrates [JMESPath](http://jmespath.org) filter and querying. This allows
+us to achieve a lot.
 
-```
-$ sit issues | xargs -I '{}' sit reduce '{}' | jq -r '.id + " | " + .summary'
-```
-
-Or, if you want to list open issues only:
+For example, we can list all issues with their ID and summary using processing query (`--query/-q`):
 
 ```
-$ sit issues | xargs -I '{}' sit reduce '{}' | jq -r 'select(.state == "open" | ).id + " | " + .summary'
+$ sit issues -q "join(' | ', [id, summary])"
+a59dfc1e-cf88-4c18-a728-23baab41f7d2 | Problem: no way to discuss issues
+efc6b084-db52-4d20-80b9-20112f679660 | Problem: sit requires to specify authorship
+885a8af0-22ff-455c-89a6-68a13597dd53 | Problem: SIT is not very ergonomic for day-to-day use
+6913711b-34ab-471f-9e83-77a719e0697a | Problem: no record authorship preserved
+09274126-7d3c-4a32-9338-a5501e1bfb84 | Problem: issue state does not account for unauthorized editing
 ```
 
-You can see the entire issue with `sit reduce <id>`.
+(The above output is just an example so that you can see what it can produce)
+
+If you want to filter out closed issues, a filtering query (`--filter/-f`) will come in handy:
+
+```
+$ sit issues -f "state != 'closed'" -q "join(' | ', [id, summary])"
+```
+
+You can list issues in their entirety as well:
+
+```
+$ sit issues -q @
+```
 
 ### Open an issue
 

--- a/sit/Cargo.toml
+++ b/sit/Cargo.toml
@@ -11,6 +11,8 @@ chrono = "0.4"
 tempfile = "2.2"
 config = { version = "0.8", features = ["json"] }
 serde = "1.0"
+serde_json = "1.0"
 serde_derive = "1.0"
 xdg = "2.1"
+jmespath = "0.2"
 sit-core = { path = "../sit-core" }


### PR DESCRIPTION
This requires users to get a separate tool for some
very basic functionality. Considering that they might
end up using something else for querying JSON,
they might end up using incompatible tools, increasing
friction in the community (if there's ever one to form).

Solution: replace jq suggestion with built-in JMESPath
filtering and querying