### PR TITLE
Problem: default issue filter is !false

### DIFF
--- a/sit/src/main.rs
+++ b/sit/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
                      .long("filter")
                      .short("f")
                      .takes_value(true)
-                     .default_value("!false")
+                     .default_value("type(@) == 'object'")
                      .help("Filter issues with a JMESPath query"))
             .arg(Arg::with_name("query")
                      .long("query")


### PR DESCRIPTION
This is a filter that's hard to explain
or remember why it was done this way.

Solution: use a self-explanatory filter
`type(@) == 'object'`