### PR TITLE
Problem: querying information from records

### DIFF
--- a/sit-core/src/repository.rs
+++ b/sit-core/src/repository.rs
@@ -370,6 +370,16 @@ pub struct Record<'a> {
     repository: &'a Repository,
 }
 
+use serde::{Serialize, Serializer};
+
+impl<'a> Serialize for Record<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        use record::RecordExt;
+        self.serde_serialize(serializer)
+    }
+}
+
+
 impl<'a> PartialEq for Record<'a> {
    fn eq(&self, other: &Record<'a>) -> bool {
        self.hash == other.hash


### PR DESCRIPTION
Currently, this would require scanning the contents of
.sit. While not a terribly bad thing, it'd be completely
outside of sit's tooling and therefore, again, everybody
would have to come up with their own solution.

Solution: add JMESPath filtering and querying to `records`
subcommand.

This is very similar to JMESPath filter and querying in
`issues`.

Also, this makes `Record` serde-serializable.

Currently, handling of binary files isn't best. Should it
base64 instead of just letting people know it is binary?

Or should it sniff the MIME type?