### PR TITLE
Problem: sit won't take value for -c/--config

### DIFF
--- a/sit/src/main.rs
+++ b/sit/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
         .arg(Arg::with_name("config")
             .short("c")
             .long("config")
+            .takes_value(true)
             .help("Config file (overrides default)"))
         .subcommand(SubCommand::with_name("init")
             .settings(&[clap::AppSettings::ColoredHelp, clap::AppSettings::ColorAuto])


### PR DESCRIPTION
This means one can't specify a custom config

Solution: ensure it does