### PR TITLE
Problem: SIT won't build and tests will fail on Windows

### DIFF
--- a/sit-core/src/repository.rs
+++ b/sit-core/src/repository.rs
@@ -468,7 +468,10 @@ impl<'a> Iterator for RecordFileIterator<'a> {
                 Some(Err(_)) => continue,
                 Some(Ok(name)) => {
                     if name.is_file() {
-                        return Some((String::from(name.strip_prefix(&prefix).unwrap().to_str().unwrap()), fs::File::open(name).unwrap()))
+                        let stripped = String::from(name.strip_prefix(&prefix).unwrap().to_str().unwrap());
+                        #[cfg(windows)] // replace backslashes with slashes
+                        let stripped = stripped.replace("\\", "/");
+                        return Some((stripped, fs::File::open(name).unwrap()))
                     } else {
                         // if it is not a file, keep iterating
                         continue

--- a/sit/src/main.rs
+++ b/sit/src/main.rs
@@ -22,11 +22,13 @@ extern crate serde_json;
 extern crate config;
 mod cfg;
 
+#[cfg(unix)]
 extern crate xdg;
 
 extern crate jmespath;
 
 fn main() {
+    #[cfg(unix)]
     let xdg_dir = xdg::BaseDirectories::with_prefix("sit").unwrap();
 
     let cwd = env::current_dir().expect("can't get current working directory");
@@ -124,8 +126,12 @@ fn main() {
         .get_matches();
 
 
-    let xdg_config = PathBuf::from(xdg_dir.place_config_file("config.json").expect("can't create config directory"));
-    let config_path = matches.value_of("config").unwrap_or(xdg_config.to_str().unwrap());
+    #[cfg(unix)]
+    let default_config = PathBuf::from(xdg_dir.place_config_file("config.json").expect("can't create config directory"));
+    #[cfg(windows)]
+    let default_config = env::home_dir().expect("can't identify home directory").join("sit_config.json");
+
+    let config_path = matches.value_of("config").unwrap_or(default_config.to_str().unwrap());
 
     let mut settings = config::Config::default();
     settings


### PR DESCRIPTION
This is because it depends on XDG, which
is not available on Windows

Solution: try finding sit config file in %HOME%\sit_config.json

Also, file iterator was returning file paths with backslashes, which is
not what tests expected.