### PR TITLE
Problem: reducers state being non-map is confusing

### DIFF
--- a/sit-core/src/reducers/core.rs
+++ b/sit-core/src/reducers/core.rs
@@ -16,25 +16,20 @@ impl<R: Record> IssueSummaryReducer<R> {
 }
 
 impl<R: Record + RecordExt> Reducer for IssueSummaryReducer<R> {
-    type State = JsonValue;
+    type State = Map<String, JsonValue>;
     type Item = R;
 
-    fn reduce(&self, state: Self::State, item: &Self::Item) -> Self::State {
+    fn reduce(&self, mut state: Self::State, item: &Self::Item) -> Self::State {
         if item.has_type("SummaryChanged") {
-            match state {
-                JsonValue::Object(mut map) => {
-                    map.insert("summary".into(), JsonValue::String(item.file("text")
-                        .and_then(|mut r| {
-                            let mut s = String::new();
-                            r.read_to_string(&mut s).unwrap();
-                            Some(String::from(s.trim()))
-                        })
-                        .or_else(|| Some(String::from("")))
-                        .unwrap()));
-                    JsonValue::Object(map)
-                }
-                _ => panic!("invalid state"),
-            }
+            state.insert("summary".into(), JsonValue::String(item.file("text")
+                .and_then(|mut r| {
+                    let mut s = String::new();
+                    r.read_to_string(&mut s).unwrap();
+                    Some(String::from(s.trim()))
+                })
+                .or_else(|| Some(String::from("")))
+                .unwrap()));
+            state
         } else {
             state
         }
@@ -52,25 +47,20 @@ impl<R: Record> IssueDetailsReducer<R> {
 }
 
 impl<R: Record + RecordExt> Reducer for IssueDetailsReducer<R> {
-    type State = JsonValue;
+    type State = Map<String, JsonValue>;
     type Item = R;
 
-    fn reduce(&self, state: Self::State, item: &Self::Item) -> Self::State {
+    fn reduce(&self, mut state: Self::State, item: &Self::Item) -> Self::State {
         if item.has_type("DetailsChanged") {
-            match state {
-                JsonValue::Object(mut map) => {
-                    map.insert("details".into(), JsonValue::String(item.file("text")
-                        .and_then(|mut r| {
-                            let mut s = String::new();
-                            r.read_to_string(&mut s).unwrap();
-                            Some(s)
-                        })
-                        .or_else(|| Some(String::from("")))
-                        .unwrap()));
-                    JsonValue::Object(map)
-                }
-                _ => panic!("invalid state"),
-            }
+            state.insert("details".into(), JsonValue::String(item.file("text")
+                .and_then(|mut r| {
+                    let mut s = String::new();
+                    r.read_to_string(&mut s).unwrap();
+                    Some(s)
+                })
+                .or_else(|| Some(String::from("")))
+                .unwrap()));
+            state
         } else {
             state
         }
@@ -87,33 +77,17 @@ impl<R: Record> IssueClosureReducer<R> {
 }
 
 impl<R: Record + RecordExt> Reducer for IssueClosureReducer<R> {
-    type State = JsonValue;
+    type State = Map<String, JsonValue>;
     type Item = R;
 
-    fn reduce(&self, state: Self::State, item: &Self::Item) -> Self::State {
-        let state = match state {
-            JsonValue::Object(mut map) => {
-                map.entry("state").or_insert(JsonValue::String("open".into()));
-                JsonValue::Object(map)
-            },
-            _ => panic!("invalid state"),
-        };
+    fn reduce(&self, mut state: Self::State, item: &Self::Item) -> Self::State {
+        state.entry("state").or_insert(JsonValue::String("open".into()));
         if item.has_type("Closed") {
-            match state {
-                JsonValue::Object(mut map) => {
-                    map.insert("state".into(), JsonValue::String("closed".into()));
-                    JsonValue::Object(map)
-                }
-                _ => panic!("invalid state"),
-            }
+            state.insert("state".into(), JsonValue::String("closed".into()));
+            state
         } else if item.has_type("Reopened") {
-             match state {
-                JsonValue::Object(mut map) => {
-                    map.insert("state".into(), JsonValue::String("open".into()));
-                    JsonValue::Object(map)
-                }
-                _ => panic!("invalid state"),
-            }
+            state.insert("state".into(), JsonValue::String("open".into()));
+            state
         } else {
             state
         }
@@ -130,55 +104,43 @@ impl<R: Record> CommentedReducer<R> {
 }
 
 impl<R: Record + RecordExt> Reducer for CommentedReducer<R> {
-    type State = JsonValue;
+    type State = Map<String, JsonValue>;
     type Item = R;
 
-    fn reduce(&self, state: Self::State, item: &Self::Item) -> Self::State {
-        let state = match state {
-            JsonValue::Object(mut map) => {
-                map.entry("comments").or_insert(JsonValue::Array(vec![]));
-                JsonValue::Object(map)
-            },
-            _ => panic!("invalid state"),
-        };
+    fn reduce(&self, mut state: Self::State, item: &Self::Item) -> Self::State {
+        state.entry("comments").or_insert(JsonValue::Array(vec![]));
         if item.has_type("Commented") {
-            match state {
-                JsonValue::Object(map) => {
-                    let mut map = map.clone();
-                    // scope it to unborrow `map` before it is returned
-                    {
-                        let mut comments = map.get_mut("comments").unwrap();
-                        let mut comment: Map<String, JsonValue> = Default::default();
-                        comment.insert("text".into(), JsonValue::String(item.file("text")
-                            .and_then(|mut r| {
-                                let mut s = String::new();
-                                r.read_to_string(&mut s).unwrap();
-                                Some(s)
-                            })
-                            .or_else(|| Some(String::from("")))
-                            .unwrap()));
-                        comment.insert("authors".into(), JsonValue::String(item.file(".authors")
-                            .and_then(|mut r| {
-                                let mut s = String::new();
-                                r.read_to_string(&mut s).unwrap();
-                                Some(s)
-                            })
-                            .or_else(|| Some(String::from("")))
-                            .unwrap()));
-                        comment.insert("timestamp".into(), JsonValue::String(item.file(".timestamp")
-                            .and_then(|mut r| {
-                                let mut s = String::new();
-                                r.read_to_string(&mut s).unwrap();
-                                Some(s)
-                            })
-                            .or_else(|| Some(String::from("")))
-                            .unwrap()));
-                        comments.as_array_mut().unwrap().push(JsonValue::Object(comment));
-                    }
-                    JsonValue::Object(map)
-                }
-                _ => panic!("invalid state"),
+            // scope it to unborrow `map` before it is returned
+            {
+                let comments = state.get_mut("comments").unwrap();
+                let mut comment: Map<String, JsonValue> = Default::default();
+                comment.insert("text".into(), JsonValue::String(item.file("text")
+                    .and_then(|mut r| {
+                        let mut s = String::new();
+                        r.read_to_string(&mut s).unwrap();
+                        Some(s)
+                    })
+                    .or_else(|| Some(String::from("")))
+                    .unwrap()));
+                comment.insert("authors".into(), JsonValue::String(item.file(".authors")
+                    .and_then(|mut r| {
+                        let mut s = String::new();
+                        r.read_to_string(&mut s).unwrap();
+                        Some(s)
+                    })
+                    .or_else(|| Some(String::from("")))
+                    .unwrap()));
+                comment.insert("timestamp".into(), JsonValue::String(item.file(".timestamp")
+                    .and_then(|mut r| {
+                        let mut s = String::new();
+                        r.read_to_string(&mut s).unwrap();
+                        Some(s)
+                    })
+                    .or_else(|| Some(String::from("")))
+                    .unwrap()));
+                comments.as_array_mut().unwrap().push(JsonValue::Object(comment));
             }
+            state
         } else {
             state
         }
@@ -199,7 +161,7 @@ impl<R: Record> BasicIssueReducer<R> {
 }
 
 impl<R: Record> Reducer for BasicIssueReducer<R> {
-    type State = JsonValue;
+    type State = Map<String, JsonValue>;
     type Item = R;
 
     fn reduce(&self, state: Self::State, item: &Self::Item) -> Self::State {
@@ -224,15 +186,15 @@ mod tests {
         let issue = repo.new_issue().unwrap();
         // no SummaryChanged
         let state = issue.reduce_with_reducer(IssueSummaryReducer::new()).unwrap();
-        assert!(!state.as_object().unwrap().contains_key("summary"));
+        assert!(!state.contains_key("summary"));
         // one SummaryChanged
         issue.new_record(vec![(".type/SummaryChanged", &b""[..]), ("text", &b"Title"[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueSummaryReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("summary").unwrap().as_str().unwrap(), "Title");
+        assert_eq!(state.get("summary").unwrap().as_str().unwrap(), "Title");
         // two SummaryChanged items
         issue.new_record(vec![(".type/SummaryChanged", &b""[..]), ("text", &b"New title"[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueSummaryReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("summary").unwrap().as_str().unwrap(), "New title");
+        assert_eq!(state.get("summary").unwrap().as_str().unwrap(), "New title");
     }
 
     #[test]
@@ -243,15 +205,15 @@ mod tests {
         let issue = repo.new_issue().unwrap();
         // no DetailsChanged
         let state = issue.reduce_with_reducer(IssueDetailsReducer::new()).unwrap();
-        assert!(!state.as_object().unwrap().contains_key("details"));
+        assert!(!state.contains_key("details"));
         // one DetailsChanged
         issue.new_record(vec![(".type/DetailsChanged", &b""[..]), ("text", &b"Explanation"[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueDetailsReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("details").unwrap().as_str().unwrap(), "Explanation");
+        assert_eq!(state.get("details").unwrap().as_str().unwrap(), "Explanation");
         // two DetailsChanged items
         issue.new_record(vec![(".type/DetailsChanged", &b""[..]), ("text", &b"New explanation"[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueDetailsReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("details").unwrap().as_str().unwrap(), "New explanation");
+        assert_eq!(state.get("details").unwrap().as_str().unwrap(), "New explanation");
     }
 
     #[test]
@@ -263,11 +225,11 @@ mod tests {
         // Closed
         issue.new_record(vec![(".type/Closed", &b""[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueClosureReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("state").unwrap().as_str().unwrap(), "closed");
+        assert_eq!(state.get("state").unwrap().as_str().unwrap(), "closed");
         // Reopened
         issue.new_record(vec![(".type/Reopened", &b""[..])].into_iter(), true).unwrap();
         let state = issue.reduce_with_reducer(IssueClosureReducer::new()).unwrap();
-        assert_eq!(state.as_object().unwrap().get("state").unwrap().as_str().unwrap(), "open");
+        assert_eq!(state.get("state").unwrap().as_str().unwrap(), "open");
     }
 
     #[test]


### PR DESCRIPTION
Basically, as far as the whole convention of reducers
if concerned, the state is a JSON object. It doesn't
make a lot of sense to allow other types (such as string,
or number) to represent a reduction. While it might have
negligible benefit to special case reduction where the
result is a single type, this affects the code of existing
regular reducers as they have to handle the fact
that incoming state might be any JSON type.

Solution: reduce the scope to JSON objects only
at the type level.